### PR TITLE
Improve front-end and add error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,14 +28,19 @@ def predict():
     if not sport:
         return jsonify({'error': 'sport is required'}), 400
 
-    sport_num = sport_enc.transform([sport])[0]
-    pred_num = model.predict([[sport_num]])[0]
-    eye_color = eye_enc.inverse_transform([pred_num])[0]
+    if sport not in sport_enc.classes_:
+        return jsonify({'error': 'sport not found'}), 400
 
-    df = pd.DataFrame([[sport, eye_color]], columns=['sport', 'predicted_eye_color'])
+    sport_num = sport_enc.transform([sport])[0]
+    proba = model.predict_proba([[sport_num]])[0]
+    pred_num = proba.argmax()
+    eye_color = eye_enc.inverse_transform([pred_num])[0]
+    probability = float(proba[pred_num])
+
+    df = pd.DataFrame([[sport, eye_color, probability]], columns=['sport', 'predicted_eye_color', 'probability'])
     df.to_csv(USER_DATA_PATH, mode='a', header=False, index=False)
 
-    return jsonify({'eye_color': eye_color})
+    return jsonify({'eye_color': eye_color, 'probability': probability})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,47 @@
 <head>
     <meta charset="UTF-8">
     <title>Eye Color Predictor</title>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Montserrat', sans-serif;
+            background-color: #f0f8ff;
+            color: #333;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+        }
+        h1 {
+            color: #ff6600;
+        }
+        form {
+            background-color: #fff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+        button {
+            background-color: #007bff;
+            color: #fff;
+            border: none;
+            padding: 10px;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: #0056b3;
+        }
+        #result {
+            margin-top: 20px;
+            font-size: 1.2em;
+        }
+    </style>
 </head>
 <body>
     <h1>Predict Eye Color by Sport</h1>
@@ -25,7 +66,8 @@
         });
         const result = await response.json();
         if (response.ok) {
-            document.getElementById('result').textContent = 'Predicted eye color: ' + result.eye_color;
+            const prob = (result.probability * 100).toFixed(1);
+            document.getElementById('result').textContent = `Predicted eye color: ${result.eye_color} (probability: ${prob}%)`;
         } else {
             document.getElementById('result').textContent = result.error;
         }


### PR DESCRIPTION
## Summary
- add error handling for unknown sports
- compute probability of predicted eye color
- log probability alongside predictions
- modernize front-end with Montserrat font and blue/orange palette
- display prediction probability and server-side errors

## Testing
- `python -m py_compile app.py train_model.py`
- `python train_model.py` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684053de7a20832f912d87970592d111